### PR TITLE
Fix Connector Framework Version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,7 @@ dependencies {
     // HTTP/RESTful support
     implementation 'com.google.code.gson:gson:2.10.1'
     implementation 'org.apache.httpcomponents:httpclient:4.5.14'
-    implementation 'net.tirasa.connid:connector-framework-internal:1.5.1.10'
+    implementation "net.tirasa.connid:connector-framework-internal:${connid_connector_framework_version}"
 
     implementation 'commons-codec:commons-codec:1.15'
 
@@ -75,7 +75,7 @@ dependencies {
 
     testImplementation "com.exclamationlabs.connid:connector-base-test-support:${test_connector_version}-+"
 
-    testImplementation 'net.tirasa.connid:connector-framework-internal:1.5.1.10'
+    testImplementation "net.tirasa.connid:connector-framework-internal:${connid_connector_framework_version}"
 }
 
 sourceSets {
@@ -112,7 +112,7 @@ task fatJar(type: Jar) {
     from 'custom', 'build/classes/java/main', 'src/main/resources'
 
     manifest {
-        attributes("ConnectorBundle-FrameworkVersion": "1.4.3.11",
+        attributes("ConnectorBundle-FrameworkVersion": connid_connector_framework_version,
                 "ConnectorBundle-Version": versionNumber,
                 "ConnectorBundle-Name": project.name)
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,3 +2,4 @@ project_version=1.2.6
 base_connector_version=4.1.11
 config_plugin_version=3.0.5
 test_connector_version=3.0.1
+connid_connector_framework_version=1.5.1.10


### PR DESCRIPTION
The `ConnectorBundle-FrameworkVersion` value in `MANIFEST.MF` is incorrect. Due to this, if this connector is deployed to  the old midPoint that doesn’t support the newer Connector Framework version, it outputs an unclear error message like the one below.

```
 2024-11-06 23:02:10,692 [] [main] ERROR (com.evolveum.midpoint.provisioning.ucf.impl.connid.ConnectorFactoryConnIdImpl): Strange error happened. ConnId is not accepting bundle file:/opt/midpoint/var/icf-connectors/connector-scim2-1.2.6-1730862623024-fat.jar. But no error is indicated.
```

Note: After the fix in this pull request, a more explicit error message is shown, clearly indicating that the version is unsupported.

```
2024-11-06 23:02:10,693 [] [main] ERROR (com.evolveum.midpoint.provisioning.ucf.impl.connid.ConnectorFactoryConnIdImpl): Error instantiating ICF bundle using URL 'file:/opt/midpoint/var/icf-connectors/connector-scim2-1.2.6-1730900929346-fat.jar': Bundle file:/opt/midpoint/var/icf-connectors/connector-scim2-1.2.6-1730900929346-fat.jar requests an unrecognized framework version 1.5.1.10 but available is 1.5.0.10
```