### PR TITLE
Conditional content on the objects and optional filter build up proces for group endpoint

### DIFF
--- a/configuration.structure.yml
+++ b/configuration.structure.yml
@@ -66,12 +66,12 @@ custom:
         order: 3090
         display: 'Short list for group/member attribute'
         help: 'To enable utilize of groups_value and members_value attribute.'
-      userInGroupSkipFilterKeyword:
+      groupSkipFilterKeyword:
         type: boolean
         default: 'false'
         order: 3091
-        display: 'Custom UserInGroup Filter'
-        help: 'Some resources does not use \"filter\" keyword for UserInGroup searching. Enable to stop using it.'
+        display: 'Custom Group Filter '
+        help: 'Some resources does not use \"filter\" keyword for Group filtering. Enable to stop using it.'
     optional:
       userSchemaIdList:
         type: string_array

--- a/configuration.structure.yml
+++ b/configuration.structure.yml
@@ -54,6 +54,12 @@ custom:
         order: 3070
         display: 'Groups Endpoint URL'
         help: 'Discovered from the resource type or entered manually'
+      selfRef:
+        type: boolean
+        default: 'false'
+        order: 3088
+        display: 'Self Reference'
+        help: 'Enable to calculate self reference value for the object.'
     optional:
       userSchemaIdList:
         type: string_array

--- a/configuration.structure.yml
+++ b/configuration.structure.yml
@@ -57,9 +57,21 @@ custom:
       selfRef:
         type: boolean
         default: 'false'
-        order: 3088
+        order: 3080
         display: 'Self Reference'
         help: 'Enable to calculate self reference value for the object.'
+      shortList:
+        type: boolean
+        default: 'false'
+        order: 3090
+        display: 'Short list for group/member attribute'
+        help: 'To enable utilize of groups_value and members_value attribute.'
+      userInGroupSkipFilterKeyword:
+        type: boolean
+        default: 'false'
+        order: 3091
+        display: 'Custom UserInGroup Filter'
+        help: 'Some resources does not use \"filter\" keyword for UserInGroup searching. Enable to stop using it.'
     optional:
       userSchemaIdList:
         type: string_array

--- a/src/main/java/com/exclamationlabs/connid/base/scim2/adapter/Scim2GroupsAdapter.java
+++ b/src/main/java/com/exclamationlabs/connid/base/scim2/adapter/Scim2GroupsAdapter.java
@@ -68,6 +68,9 @@ public class Scim2GroupsAdapter extends BaseAdapter<Scim2Group, Scim2Configurati
      * value, $ref, and type
      */
     result.add(new ConnectorAttribute(members.name(), STRING, MULTIVALUED));
+    if ( configuration.getSelfRef() != null && configuration.getSelfRef() ) {
+      result.add(new ConnectorAttribute(selfRef.name(), STRING, NOT_CREATABLE, NOT_UPDATEABLE));
+    }
 
     return result;
   }
@@ -97,9 +100,42 @@ public class Scim2GroupsAdapter extends BaseAdapter<Scim2Group, Scim2Configurati
           memberSet.add(member);
       }
       attributes.add(AttributeBuilder.build(members.name(), memberSet));
+      if ( configuration.getSelfRef() != null && configuration.getSelfRef() ) {
+        attributes.add(AttributeBuilder.build(selfRef.name(), builderSelfRef(group)));
+      }
     }
     return attributes;
   }
+
+  /**
+   * Generate the structured information containing the self reference (e.g. for the comparing of the objects)
+   *
+   * @param group
+   * @return json structured Self reference
+   */
+  private String builderSelfRef(Scim2Group group) {
+    String result;
+    Gson gson = new Gson();
+    Map<String, String> retValue = new LinkedHashMap<>();
+
+    if ( group != null ) {
+      retValue.put("value", group.getId());
+      retValue.put("$ref",
+              configuration.getServiceUrl() +
+                      Objects.toString(configuration.getGroupsEndpointUrl(), "") +
+                      "/" + group.getId()
+      );
+      retValue.put("display", Objects.toString(group.getDisplayName(), ""));
+      result = gson.toJson(retValue);
+      if (result != null) {
+        if (!result.isEmpty()) {
+          return result;
+        }
+      }
+    }
+    return "";
+  }
+
 
   @Override
   protected Scim2Group constructModel(

--- a/src/main/java/com/exclamationlabs/connid/base/scim2/adapter/Scim2UserAdapter.java
+++ b/src/main/java/com/exclamationlabs/connid/base/scim2/adapter/Scim2UserAdapter.java
@@ -217,7 +217,6 @@ public class Scim2UserAdapter extends BaseAdapter<Scim2User, Scim2Configuration>
         }
         return set;
       }
-    }
     return null;
   }
 

--- a/src/main/java/com/exclamationlabs/connid/base/scim2/adapter/Scim2UserAdapter.java
+++ b/src/main/java/com/exclamationlabs/connid/base/scim2/adapter/Scim2UserAdapter.java
@@ -198,11 +198,10 @@ public class Scim2UserAdapter extends BaseAdapter<Scim2User, Scim2Configuration>
     * @return Set of JSON formatted strings
     */
   public Set<String> getSetOfJSONFromListOfMap(Boolean shortList, List<Map<String, String>> list){
-    if ( list != null ) {
-      if ( list.size() > 0 ) {
+    if ( list != null && list.size() > 0 ) {
         Set<String> set = new HashSet<>();
         for(Map<String, String> item: list) {
-          if (shortList) {
+          if ( shortList != null && shortList) {
             item.forEach((key, value) -> {
               if (key.equals("value")) {
                 set.add(value);

--- a/src/main/java/com/exclamationlabs/connid/base/scim2/attribute/Scim2GroupAttribute.java
+++ b/src/main/java/com/exclamationlabs/connid/base/scim2/attribute/Scim2GroupAttribute.java
@@ -8,5 +8,6 @@ public enum Scim2GroupAttribute {
   members,
   members_value,
   members_$ref,
-  members_type
+  members_type,
+  selfRef
 }

--- a/src/main/java/com/exclamationlabs/connid/base/scim2/attribute/Scim2UserAttribute.java
+++ b/src/main/java/com/exclamationlabs/connid/base/scim2/attribute/Scim2UserAttribute.java
@@ -74,7 +74,8 @@ public enum Scim2UserAttribute {
   x509Certificates_value,
   x509Certificates_display,
   x509Certificates_type,
-  x509Certificates_primary;
+  x509Certificates_primary,
+  selfRef;
 
 
   Scim2UserAttribute(String s) {

--- a/src/main/java/com/exclamationlabs/connid/base/scim2/driver.rest/Scim2GroupsInvocator.java
+++ b/src/main/java/com/exclamationlabs/connid/base/scim2/driver.rest/Scim2GroupsInvocator.java
@@ -164,7 +164,14 @@ public class Scim2GroupsInvocator implements DriverInvocator<Scim2Driver, Scim2G
     Scim2Group group = null;
     Scim2Configuration config = driver.getConfiguration();
     String displayName = URLEncoder.encode(objectName);
-    String query = "?filter=displayName+eq+%22" + displayName + "%22";
+    String query;
+    if (driver.getConfiguration().getGroupSkipFilterKeyword() != null &&
+            driver.getConfiguration().getGroupSkipFilterKeyword() ) {
+      query = "?displayName+eq+%22" + displayName + "%22";
+    } else {
+      query = "?filter=displayName+eq+%22" + displayName + "%22";
+    }
+
     RestRequest<ListGroupResponse> request =
             new RestRequest.Builder<>(ListGroupResponse.class)
                     .withGet()
@@ -283,11 +290,14 @@ public class Scim2GroupsInvocator implements DriverInvocator<Scim2Driver, Scim2G
   private Set<Map<String, String>> getUsersForGroup(Scim2Driver driver, String groupId) {
     Set<Map<String, String>> groupMaps = new HashSet<>();
     try {
+      String filter = String.format("groups.value eq \"%s\"",
+              URLEncoder.encode(groupId, StandardCharsets.UTF_8.toString()));
+      String query = "?filter=" + URLEncoder.encode(filter, StandardCharsets.UTF_8.toString());
 
       RestRequest<ListUsersResponse> request =
               new RestRequest.Builder<>(ListUsersResponse.class)
                       .withGet()
-                      .withRequestUri(driver.getConfiguration().getUsersEndpointUrl()  )
+                      .withRequestUri(driver.getConfiguration().getUsersEndpointUrl() + query )
                       .build();
       RestResponseData<ListUsersResponse> data = driver.executeRequest(request);
       ListUsersResponse response = data.getResponseObject();
@@ -326,7 +336,13 @@ public class Scim2GroupsInvocator implements DriverInvocator<Scim2Driver, Scim2G
     String filter = String.format("id eq \"%s\" and members eq \"%s\"",
             URLEncoder.encode(groupId, StandardCharsets.UTF_8.toString()),
             URLEncoder.encode(userId, StandardCharsets.UTF_8.toString()));
-    String query = "?filter=" + URLEncoder.encode(filter, StandardCharsets.UTF_8.toString());
+    String query;
+    if (driver.getConfiguration().getGroupSkipFilterKeyword() != null &&
+            driver.getConfiguration().getGroupSkipFilterKeyword() ) {
+      query = "?" + URLEncoder.encode(filter, StandardCharsets.UTF_8.toString());
+    } else {
+      query = "?filter=" + URLEncoder.encode(filter, StandardCharsets.UTF_8.toString());
+    }
 
     RestRequest<ListGroupResponse> request =
             new RestRequest.Builder<>(ListGroupResponse.class)

--- a/src/main/java/com/exclamationlabs/connid/base/scim2/driver.rest/Scim2UsersInvocator.java
+++ b/src/main/java/com/exclamationlabs/connid/base/scim2/driver.rest/Scim2UsersInvocator.java
@@ -478,7 +478,13 @@ public class Scim2UsersInvocator implements DriverInvocator<Scim2Driver, Scim2Us
         String filter = String.format("id eq \"%s\" and members eq \"%s\"",
                 URLEncoder.encode(groupId, StandardCharsets.UTF_8.toString()),
                 URLEncoder.encode(userId, StandardCharsets.UTF_8.toString()));
-        String query = "?filter=" + URLEncoder.encode(filter, StandardCharsets.UTF_8.toString());
+        String query = "";
+        if (driver.getConfiguration().getUserInGroupSkipFilterKeyword() != null &&
+                driver.getConfiguration().getUserInGroupSkipFilterKeyword() ) {
+            query = "?" + URLEncoder.encode(filter, StandardCharsets.UTF_8.toString());
+        } else {
+            query = "?filter=" + URLEncoder.encode(filter, StandardCharsets.UTF_8.toString());
+        }
 
         RestRequest<ListGroupResponse> request =
                 new RestRequest.Builder<>(ListGroupResponse.class)

--- a/src/main/java/com/exclamationlabs/connid/base/scim2/driver.rest/Scim2UsersInvocator.java
+++ b/src/main/java/com/exclamationlabs/connid/base/scim2/driver.rest/Scim2UsersInvocator.java
@@ -479,8 +479,8 @@ public class Scim2UsersInvocator implements DriverInvocator<Scim2Driver, Scim2Us
                 URLEncoder.encode(groupId, StandardCharsets.UTF_8.toString()),
                 URLEncoder.encode(userId, StandardCharsets.UTF_8.toString()));
         String query = "";
-        if (driver.getConfiguration().getUserInGroupSkipFilterKeyword() != null &&
-                driver.getConfiguration().getUserInGroupSkipFilterKeyword() ) {
+        if (driver.getConfiguration().getGroupSkipFilterKeyword() != null &&
+                driver.getConfiguration().getGroupSkipFilterKeyword() ) {
             query = "?" + URLEncoder.encode(filter, StandardCharsets.UTF_8.toString());
         } else {
             query = "?filter=" + URLEncoder.encode(filter, StandardCharsets.UTF_8.toString());


### PR DESCRIPTION
There have been added 3 independent things. For each there is added attribute in the connector configuration - default value is false and until these are set to true (so other than false or null) there is no change in behavior.

- selfRef
Calculated value of the Object with self reference. There is used endpoint configuration on the Connector itself.
There is added the option into the configuration with default value of FALSE. Until it is set to TRUE there is no change.

- shortList
The content groups_value@user and members_value@group is prepared with just string value of ID of the referenced object. This can be used on some system to easily link the relation : id@user <=> members_value@group / groups_value@user <=>  id@group. Default value of the configuration attribute is false. No impact on result until it is explicitly set to true.

- custom Group filter
Some system not use prefix "filter=" in case of group endpoint. Example of the resource is https://scim.dev/ . Until the configuration attribute is set to true the old behavior is kapt (backword compatility). Once the attribute in the configuration is set to true, there is omitting the prefix "filter=" in case of group endpoint.
